### PR TITLE
feat: Added env vars for OTel traces + Single revision mode

### DIFF
--- a/src/core/09_mil_fee_calculator.tf
+++ b/src/core/09_mil_fee_calculator.tf
@@ -88,7 +88,7 @@ resource "azurerm_container_app" "fee_calculator" {
   name                         = "${local.project}-fee-calculator-ca"
   container_app_environment_id = azurerm_container_app_environment.mil.id
   resource_group_name          = azurerm_resource_group.app.name
-  revision_mode                = "Multiple"
+  revision_mode                = "Single"
 
   template {
     container {
@@ -151,6 +151,11 @@ resource "azurerm_container_app" "fee_calculator" {
         name  = "jwt-publickey-location"
         value = "${azurerm_api_management.mil.gateway_url}/${var.mil_auth_path}/.well-known/jwks.json"
       }
+      
+      env {
+        name  = "application-insights.connection-string"
+        value = azurerm_application_insights.mil.connection_string
+      }
     }
 
     max_replicas = var.mil_fee_calculator_max_replicas
@@ -198,6 +203,12 @@ resource "azurerm_log_analytics_query_pack_query" "fee_calculator_ca_console_log
   query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
   body          = "ContainerAppConsoleLogs_CL | where ContainerName_s == 'mil-fee-calculator' | where time_t > ago(60m) | sort by time_t asc | extend local_time = substring(Log_s, 0, 23) | extend request_id = extract('\\\\[(.*?)\\\\]', 1, Log_s) | extend log_level = extract('\\\\[(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\\\\]', 1, Log_s) | project local_time, request_id, log_level, Log_s"
   display_name  = "*** mil-fee-calculator - last hour logs ***"
+}
+
+resource "azurerm_log_analytics_query_pack_query" "fee_calculator_ca_json_logs" {
+  query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
+  body          = "ContainerAppConsoleLogs_CL\n| where ContainerName_s == 'mil-fee-calculator'\n| where time_t > ago(60m)\n| sort by time_t asc\n| extend ParsedJSON = parse_json(Log_s)\n| project \n    app_timestamp=ParsedJSON.timestamp,\n    app_sequence=ParsedJSON.sequence,\n    app_loggerClassName=ParsedJSON.loggerClassName,\n    app_loggerName=ParsedJSON.loggerName,\n    app_level=ParsedJSON.level,\n    app_message=ParsedJSON.message,\n    app_threadName=ParsedJSON.threadName,\n    app_threadId=ParsedJSON.threadId,\n    app_mdc=ParsedJSON.mdc,\n    app_requestId=ParsedJSON.mdc.requestId,\n    app_ndc=ParsedJSON.ndc,\n    app_hostName=ParsedJSON.hostName,\n    app_processId=ParsedJSON.processId"
+  display_name  = "*** mil-fee-calculator - last hour json logs ***"
 }
 
 # ------------------------------------------------------------------------------

--- a/src/core/09_mil_idpay.tf
+++ b/src/core/09_mil_idpay.tf
@@ -185,7 +185,7 @@ resource "azurerm_container_app" "idpay" {
   name                         = "${local.project}-idpay-ca"
   container_app_environment_id = azurerm_container_app_environment.mil.id
   resource_group_name          = azurerm_resource_group.app.name
-  revision_mode                = "Multiple"
+  revision_mode                = "Single"
 
   template {
     container {
@@ -287,6 +287,11 @@ resource "azurerm_container_app" "idpay" {
         name  = "azure-cert.name"
         value = var.mil_idpay_client_cert_name
       }
+      
+      env {
+        name  = "application-insights.connection-string"
+        value = azurerm_application_insights.mil.connection_string
+      }
     }
 
     max_replicas = var.mil_idpay_max_replicas
@@ -334,6 +339,12 @@ resource "azurerm_log_analytics_query_pack_query" "mil_idpay_ca_console_logs" {
   query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
   body          = "ContainerAppConsoleLogs_CL | where ContainerName_s == 'mil-idpay' | where time_t > ago(60m) | sort by time_t asc | extend local_time = substring(Log_s, 0, 23) | extend request_id = extract('\\\\[(.*?)\\\\]', 1, Log_s) | extend log_level = extract('\\\\[(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\\\\]', 1, Log_s) | project local_time, request_id, log_level, Log_s"
   display_name  = "*** mil-idpay - last hour logs ***"
+}
+
+resource "azurerm_log_analytics_query_pack_query" "mil_idpay_ca_json_logs" {
+  query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
+  body          = "ContainerAppConsoleLogs_CL\n| where ContainerName_s == 'mil-idpay'\n| where time_t > ago(60m)\n| sort by time_t asc\n| extend ParsedJSON = parse_json(Log_s)\n| project \n    app_timestamp=ParsedJSON.timestamp,\n    app_sequence=ParsedJSON.sequence,\n    app_loggerClassName=ParsedJSON.loggerClassName,\n    app_loggerName=ParsedJSON.loggerName,\n    app_level=ParsedJSON.level,\n    app_message=ParsedJSON.message,\n    app_threadName=ParsedJSON.threadName,\n    app_threadId=ParsedJSON.threadId,\n    app_mdc=ParsedJSON.mdc,\n    app_requestId=ParsedJSON.mdc.requestId,\n    app_ndc=ParsedJSON.ndc,\n    app_hostName=ParsedJSON.hostName,\n    app_processId=ParsedJSON.processId"
+  display_name  = "*** mil-idpay - last hour json logs ***"
 }
 
 # ------------------------------------------------------------------------------

--- a/src/core/09_mil_payment_notice.tf
+++ b/src/core/09_mil_payment_notice.tf
@@ -57,9 +57,9 @@ variable "mil_payment_notice_node_soap_client_req_resp_log_level" {
 }
 
 variable "mil_payment_notice_rest_client_req_resp_log_level" {
-description = "Set to DEBUG to log requests and responses of all REST clients."
-  type      = string
-  default   = "ERROR"
+  description = "Set to DEBUG to log requests and responses of all REST clients."
+  type        = string
+  default     = "ERROR"
 }
 
 variable "mil_payment_notice_rest_client_connect_timeout" {
@@ -291,15 +291,15 @@ resource "azurerm_container_app" "payment_notice" {
         name        = "node.soap-client.apim-subscription-key"
         secret_name = "node-soap-subscription-key"
       }
-      
+
       env {
         name  = "node.soap-client.req-resp.log-level"
-        value = var.mil_payment_notice_node_soap_client_req_resp_log_level      
+        value = var.mil_payment_notice_node_soap_client_req_resp_log_level
       }
-      
+
       env {
         name  = "rest-client.req-resp.log-level"
-        value = var.mil_payment_notice_rest_client_req_resp_log_level      
+        value = var.mil_payment_notice_rest_client_req_resp_log_level
       }
 
       env {
@@ -385,6 +385,11 @@ resource "azurerm_container_app" "payment_notice" {
       env {
         name  = "jwt-publickey-location"
         value = "${azurerm_api_management.mil.gateway_url}/${var.mil_auth_path}/.well-known/jwks.json"
+      }
+      
+      env {
+        name  = "application-insights.connection-string"
+        value = azurerm_application_insights.mil.connection_string
       }
     }
 

--- a/src/core/09_mil_preset.tf
+++ b/src/core/09_mil_preset.tf
@@ -126,7 +126,7 @@ resource "azurerm_container_app" "preset" {
   name                         = "${local.project}-preset-ca"
   container_app_environment_id = azurerm_container_app_environment.mil.id
   resource_group_name          = azurerm_resource_group.app.name
-  revision_mode                = "Multiple"
+  revision_mode                = "Single"
 
   template {
     container {
@@ -204,6 +204,11 @@ resource "azurerm_container_app" "preset" {
         name  = "jwt-publickey-location"
         value = "${azurerm_api_management.mil.gateway_url}/${var.mil_auth_path}/.well-known/jwks.json"
       }
+      
+      env {
+        name  = "application-insights.connection-string"
+        value = azurerm_application_insights.mil.connection_string
+      }
     }
 
     max_replicas = var.mil_preset_max_replicas
@@ -256,6 +261,12 @@ resource "azurerm_log_analytics_query_pack_query" "mil_preset_ca_console_logs" {
   query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
   body          = "ContainerAppConsoleLogs_CL | where ContainerName_s == 'mil-preset' | where time_t > ago(60m) | sort by time_t asc | extend local_time = substring(Log_s, 0, 23) | extend request_id = extract('\\\\[(.*?)\\\\]', 1, Log_s) | extend log_level = extract('\\\\[(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\\\\]', 1, Log_s) | project local_time, request_id, log_level, Log_s"
   display_name  = "*** mil-preset - last hour logs ***"
+}
+
+resource "azurerm_log_analytics_query_pack_query" "mil_preset_ca_json_logs" {
+  query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
+  body          = "ContainerAppConsoleLogs_CL\n| where ContainerName_s == 'mil-preset'\n| where time_t > ago(60m)\n| sort by time_t asc\n| extend ParsedJSON = parse_json(Log_s)\n| project \n    app_timestamp=ParsedJSON.timestamp,\n    app_sequence=ParsedJSON.sequence,\n    app_loggerClassName=ParsedJSON.loggerClassName,\n    app_loggerName=ParsedJSON.loggerName,\n    app_level=ParsedJSON.level,\n    app_message=ParsedJSON.message,\n    app_threadName=ParsedJSON.threadName,\n    app_threadId=ParsedJSON.threadId,\n    app_mdc=ParsedJSON.mdc,\n    app_requestId=ParsedJSON.mdc.requestId,\n    app_ndc=ParsedJSON.ndc,\n    app_hostName=ParsedJSON.hostName,\n    app_processId=ParsedJSON.processId"
+  display_name  = "*** mil-preset - last hour json logs ***"
 }
 
 # ------------------------------------------------------------------------------

--- a/src/core/09_mil_terminal_registry.tf
+++ b/src/core/09_mil_terminal_registry.tf
@@ -71,7 +71,7 @@ resource "azurerm_container_app" "terminal_registry" {
   name                         = "${local.project}-terminal-registry-ca"
   container_app_environment_id = azurerm_container_app_environment.mil.id
   resource_group_name          = azurerm_resource_group.app.name
-  revision_mode                = "Multiple"
+  revision_mode                = "Single"
 
   template {
     container {
@@ -120,6 +120,15 @@ resource "azurerm_container_app" "terminal_registry" {
         value = var.mil_terminal_registry_mongo_server_selection_timeout
       }
 
+      env {
+        name  = "jwt-publickey-location"
+        value = "${azurerm_api_management.mil.gateway_url}/${var.mil_auth_path}/.well-known/jwks.json"
+      }
+      
+      env {
+        name  = "application-insights.connection-string"
+        value = azurerm_application_insights.mil.connection_string
+      }
     }
 
     max_replicas = var.mil_terminal_registry_max_replicas
@@ -163,6 +172,12 @@ resource "azurerm_log_analytics_query_pack_query" "mil_terminal_registry_ca_cons
   query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
   body          = "ContainerAppConsoleLogs_CL | where ContainerName_s == 'mil-terminal-registry' | where time_t > ago(60m) | sort by time_t asc | extend local_time = substring(Log_s, 0, 23) | extend request_id = extract('\\\\[(.*?)\\\\]', 1, Log_s) | extend log_level = extract('\\\\[(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)\\\\]', 1, Log_s) | project local_time, request_id, log_level, Log_s"
   display_name  = "*** mil-terminal_registry - last hour logs ***"
+}
+
+resource "azurerm_log_analytics_query_pack_query" "mil_terminal_registry_ca_json_logs" {
+  query_pack_id = azurerm_log_analytics_query_pack.query_pack.id
+  body          = "ContainerAppConsoleLogs_CL\n| where ContainerName_s == 'mil-terminal-registry'\n| where time_t > ago(60m)\n| sort by time_t asc\n| extend ParsedJSON = parse_json(Log_s)\n| project \n    app_timestamp=ParsedJSON.timestamp,\n    app_sequence=ParsedJSON.sequence,\n    app_loggerClassName=ParsedJSON.loggerClassName,\n    app_loggerName=ParsedJSON.loggerName,\n    app_level=ParsedJSON.level,\n    app_message=ParsedJSON.message,\n    app_threadName=ParsedJSON.threadName,\n    app_threadId=ParsedJSON.threadId,\n    app_mdc=ParsedJSON.mdc,\n    app_requestId=ParsedJSON.mdc.requestId,\n    app_ndc=ParsedJSON.ndc,\n    app_hostName=ParsedJSON.hostName,\n    app_processId=ParsedJSON.processId"
+  display_name  = "*** mil-terminal-registry - last hour json logs ***"
 }
 
 # ------------------------------------------------------------------------------

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -5,16 +5,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.5 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | = 2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.82.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | = 2.48.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | = 3.99.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.46.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.82.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.48.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.1 |
 
 ## Modules
 
@@ -24,146 +24,147 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_api_management.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management) | resource |
-| [azurerm_api_management_api.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api) | resource |
-| [azurerm_api_management_api_diagnostic.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_diagnostic) | resource |
-| [azurerm_api_management_api_diagnostic.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_diagnostic) | resource |
-| [azurerm_api_management_api_diagnostic.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_diagnostic) | resource |
-| [azurerm_api_management_api_diagnostic.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_diagnostic) | resource |
-| [azurerm_api_management_api_diagnostic.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_diagnostic) | resource |
-| [azurerm_api_management_api_operation_policy.mock_gec](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_operation_policy) | resource |
-| [azurerm_api_management_api_operation_policy.mock_nodo_rest](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_operation_policy) | resource |
-| [azurerm_api_management_api_operation_policy.mock_nodo_soap](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_operation_policy) | resource |
-| [azurerm_api_management_api_policy.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_api_policy) | resource |
-| [azurerm_api_management_diagnostic.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_diagnostic) | resource |
-| [azurerm_api_management_logger.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_logger) | resource |
-| [azurerm_api_management_product.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product) | resource |
-| [azurerm_api_management_product_api.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_product_api.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_product_api) | resource |
-| [azurerm_api_management_subscription.tracing](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/api_management_subscription) | resource |
-| [azurerm_application_insights.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/application_insights) | resource |
-| [azurerm_container_app.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app) | resource |
-| [azurerm_container_app_environment.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_app_environment) | resource |
-| [azurerm_container_group.vpn_dns_forwarder](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/container_group) | resource |
-| [azurerm_cosmosdb_account.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_account) | resource |
-| [azurerm_cosmosdb_mongo_collection.idpayLocalTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.idpayTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.initiatives](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.paymentTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.presets](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.subscribers](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_collection.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_collection) | resource |
-| [azurerm_cosmosdb_mongo_database.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_database) | resource |
-| [azurerm_cosmosdb_mongo_database.mock_idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/cosmosdb_mongo_database) | resource |
-| [azurerm_dns_caa_record.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/dns_caa_record) | resource |
-| [azurerm_dns_ns_record.dev_mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/dns_ns_record) | resource |
-| [azurerm_dns_ns_record.uat_mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/dns_ns_record) | resource |
-| [azurerm_dns_zone.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/dns_zone) | resource |
-| [azurerm_eventhub.presets](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/eventhub) | resource |
-| [azurerm_eventhub_namespace.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/eventhub_namespace) | resource |
-| [azurerm_federated_identity_credential.identity_credentials_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/federated_identity_credential) | resource |
-| [azurerm_key_vault.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/key_vault) | resource |
-| [azurerm_key_vault.general](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/key_vault) | resource |
-| [azurerm_key_vault.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/key_vault) | resource |
-| [azurerm_log_analytics_query_pack.query_pack](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack) | resource |
-| [azurerm_log_analytics_query_pack_query.auth_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.failed_requestes](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.fee_calculator_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.mil_errors_container_app_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.mil_idpay_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.mil_preset_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.mil_terminal_registry_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_query_pack_query.payment_notice_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_query_pack_query) | resource |
-| [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/log_analytics_workspace) | resource |
-| [azurerm_private_dns_zone.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone.storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_dns_zone_virtual_network_link.storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
-| [azurerm_private_endpoint.auth_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.auth_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.conf_storage_pep](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.idpay_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_private_endpoint.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/private_endpoint) | resource |
-| [azurerm_public_ip.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/public_ip) | resource |
-| [azurerm_redis_cache.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/redis_cache) | resource |
-| [azurerm_resource_group.app](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.data](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.integration](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.managed_identities_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.monitor](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_resource_group.sec](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.auth_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.auth_kv_to_read_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.auth_kv_to_read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.auth_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.conf_storage_for_fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.conf_storage_for_payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.identity_rg_role_assignment_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.identity_subscription_role_assignment_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.idpay_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.idpay_kv_to_read_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.idpay_kv_to_read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/role_assignment) | resource |
-| [azurerm_storage_account.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_account.conf](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_account.mock](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_blob.stub_gec](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_blob) | resource |
-| [azurerm_storage_blob.stub_verify_ko_activate_ko](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_blob) | resource |
-| [azurerm_storage_blob.stub_verify_ok_activate_ko](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_blob) | resource |
-| [azurerm_storage_blob.stub_verify_ok_activate_ok](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_blob) | resource |
-| [azurerm_storage_container.mock](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/storage_container) | resource |
-| [azurerm_subnet.apim](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.app](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.appgw](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.dns_forwarder_snet](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/subnet) | resource |
-| [azurerm_user_assigned_identity.identity_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_virtual_network.integr](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network.intern](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_gateway.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/resources/virtual_network_gateway) | resource |
+| [azurerm_api_management.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management) | resource |
+| [azurerm_api_management_api.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api_diagnostic.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_diagnostic) | resource |
+| [azurerm_api_management_api_diagnostic.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_diagnostic) | resource |
+| [azurerm_api_management_api_diagnostic.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_diagnostic) | resource |
+| [azurerm_api_management_api_diagnostic.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_diagnostic) | resource |
+| [azurerm_api_management_api_diagnostic.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_diagnostic) | resource |
+| [azurerm_api_management_api_operation_policy.mock_gec](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.mock_nodo_rest](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.mock_nodo_soap](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_policy.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_api_policy) | resource |
+| [azurerm_api_management_diagnostic.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_diagnostic) | resource |
+| [azurerm_api_management_logger.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_logger) | resource |
+| [azurerm_api_management_product.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product) | resource |
+| [azurerm_api_management_product_api.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_product_api.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_subscription.tracing](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/api_management_subscription) | resource |
+| [azurerm_application_insights.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/application_insights) | resource |
+| [azurerm_container_app.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.mock_idpay_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.preset](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app) | resource |
+| [azurerm_container_app_environment.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_app_environment) | resource |
+| [azurerm_container_group.vpn_dns_forwarder](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/container_group) | resource |
+| [azurerm_cosmosdb_account.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_account) | resource |
+| [azurerm_cosmosdb_mongo_collection.idpayLocalTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.idpayTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.initiatives](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.paymentTransactions](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.presets](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.subscribers](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_collection.terminal_registry](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_collection) | resource |
+| [azurerm_cosmosdb_mongo_database.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_database) | resource |
+| [azurerm_cosmosdb_mongo_database.mock_idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/cosmosdb_mongo_database) | resource |
+| [azurerm_dns_caa_record.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/dns_caa_record) | resource |
+| [azurerm_dns_ns_record.dev_mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/dns_ns_record) | resource |
+| [azurerm_dns_ns_record.uat_mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/dns_ns_record) | resource |
+| [azurerm_dns_zone.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/dns_zone) | resource |
+| [azurerm_eventhub.presets](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/eventhub) | resource |
+| [azurerm_eventhub_namespace.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/eventhub_namespace) | resource |
+| [azurerm_federated_identity_credential.identity_credentials_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/federated_identity_credential) | resource |
+| [azurerm_key_vault.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault) | resource |
+| [azurerm_key_vault.general](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault) | resource |
+| [azurerm_key_vault.idpay](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault) | resource |
+| [azurerm_log_analytics_query_pack.query_pack](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack) | resource |
+| [azurerm_log_analytics_query_pack_query.auth_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.failed_requestes](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.fee_calculator_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.mil_errors_container_app_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.mil_idpay_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.mil_preset_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.mil_terminal_registry_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.payment_notice_ca_console_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_query_pack_query.payment_notice_ca_json_logs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_query_pack_query) | resource |
+| [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_private_dns_zone.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_endpoint.auth_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.auth_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.conf_storage_pep](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.eventhub](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.idpay_key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.redis](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/private_endpoint) | resource |
+| [azurerm_public_ip.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/public_ip) | resource |
+| [azurerm_redis_cache.mil](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/redis_cache) | resource |
+| [azurerm_resource_group.app](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.data](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.integration](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.managed_identities_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.monitor](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.sec](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.auth_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.auth_kv_to_read_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.auth_kv_to_read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.auth_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.conf_storage_for_fee_calculator](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.conf_storage_for_payment_notice](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.identity_rg_role_assignment_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.identity_subscription_role_assignment_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.idpay_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.idpay_kv_to_read_certificates](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.idpay_kv_to_read_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_storage_account.auth](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_account.conf](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_account.mock](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_blob.stub_gec](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_blob) | resource |
+| [azurerm_storage_blob.stub_verify_ko_activate_ko](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_blob) | resource |
+| [azurerm_storage_blob.stub_verify_ok_activate_ko](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_blob) | resource |
+| [azurerm_storage_blob.stub_verify_ok_activate_ok](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_blob) | resource |
+| [azurerm_storage_container.mock](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_container) | resource |
+| [azurerm_subnet.apim](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.app](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.appgw](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.dns_forwarder_snet](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet) | resource |
+| [azurerm_user_assigned_identity.identity_cd](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_virtual_network.integr](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network.intern](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_gateway.vpn](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_gateway) | resource |
 | [random_string.dns](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [azuread_application.vpn_app](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/application) | data source |
-| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/group) | data source |
-| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/group) | data source |
-| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/group) | data source |
-| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/group) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/client_config) | data source |
-| [azurerm_key_vault_secret.apim_publisher_email](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.client_id_mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.client_secret_mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.gec_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.idpay_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.idpay_subscription_key_for_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.node_rest_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_key_vault_secret.node_soap_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.82.0/docs/data-sources/subscription) | data source |
+| [azuread_application.vpn_app](https://registry.terraform.io/providers/hashicorp/azuread/2.48.0/docs/data-sources/application) | data source |
+| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.48.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.48.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.48.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.48.0/docs/data-sources/group) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault_secret.apim_publisher_email](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.client_id_mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.client_secret_mock_nodo](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.gec_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.idpay_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.idpay_subscription_key_for_ipzs](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.node_rest_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.node_soap_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
@@ -249,11 +250,13 @@ No modules.
 | <a name="input_mil_payment_notice_mongo_server_selection_timeout"></a> [mil\_payment\_notice\_mongo\_server\_selection\_timeout](#input\_mil\_payment\_notice\_mongo\_server\_selection\_timeout) | n/a | `string` | `"5s"` | no |
 | <a name="input_mil_payment_notice_node_soap_client_connect_timeout"></a> [mil\_payment\_notice\_node\_soap\_client\_connect\_timeout](#input\_mil\_payment\_notice\_node\_soap\_client\_connect\_timeout) | n/a | `number` | `2000` | no |
 | <a name="input_mil_payment_notice_node_soap_client_read_timeout"></a> [mil\_payment\_notice\_node\_soap\_client\_read\_timeout](#input\_mil\_payment\_notice\_node\_soap\_client\_read\_timeout) | n/a | `number` | `2000` | no |
+| <a name="input_mil_payment_notice_node_soap_client_req_resp_log_level"></a> [mil\_payment\_notice\_node\_soap\_client\_req\_resp\_log\_level](#input\_mil\_payment\_notice\_node\_soap\_client\_req\_resp\_log\_level) | Set to INFO to log requests and responses of SOAP client for communicating with Nodo. | `string` | `"ERROR"` | no |
 | <a name="input_mil_payment_notice_openapi_descriptor"></a> [mil\_payment\_notice\_openapi\_descriptor](#input\_mil\_payment\_notice\_openapi\_descriptor) | n/a | `string` | n/a | yes |
 | <a name="input_mil_payment_notice_path"></a> [mil\_payment\_notice\_path](#input\_mil\_payment\_notice\_path) | n/a | `string` | `"mil-payment-notice"` | no |
 | <a name="input_mil_payment_notice_quarkus_log_level"></a> [mil\_payment\_notice\_quarkus\_log\_level](#input\_mil\_payment\_notice\_quarkus\_log\_level) | ------------------------------------------------------------------------------ Variables definition. ------------------------------------------------------------------------------ | `string` | `"ERROR"` | no |
 | <a name="input_mil_payment_notice_rest_client_connect_timeout"></a> [mil\_payment\_notice\_rest\_client\_connect\_timeout](#input\_mil\_payment\_notice\_rest\_client\_connect\_timeout) | n/a | `number` | `2000` | no |
 | <a name="input_mil_payment_notice_rest_client_read_timeout"></a> [mil\_payment\_notice\_rest\_client\_read\_timeout](#input\_mil\_payment\_notice\_rest\_client\_read\_timeout) | n/a | `number` | `2000` | no |
+| <a name="input_mil_payment_notice_rest_client_req_resp_log_level"></a> [mil\_payment\_notice\_rest\_client\_req\_resp\_log\_level](#input\_mil\_payment\_notice\_rest\_client\_req\_resp\_log\_level) | Set to DEBUG to log requests and responses of all REST clients. | `string` | `"ERROR"` | no |
 | <a name="input_mil_preset_app_log_level"></a> [mil\_preset\_app\_log\_level](#input\_mil\_preset\_app\_log\_level) | n/a | `string` | `"DEBUG"` | no |
 | <a name="input_mil_preset_cpu"></a> [mil\_preset\_cpu](#input\_mil\_preset\_cpu) | n/a | `number` | `1` | no |
 | <a name="input_mil_preset_image"></a> [mil\_preset\_image](#input\_mil\_preset\_image) | n/a | `string` | n/a | yes |

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -4,8 +4,8 @@
 env_short      = "d"
 env            = "dev"
 prefix         = "mil"
-location       = "westeurope"
-location_short = "weu"
+location       = "westeurope" # this will be "italynorth"
+location_short = "weu"        # this will be "itn"
 
 tags = {
   CreatedBy   = "Terraform"
@@ -99,7 +99,7 @@ mil_payment_notice_min_replicas                        = 1
 # mil-fee-calculator
 #
 mil_fee_calculator_image               = "ghcr.io/pagopa/mil-fee-calculator:latest"
-mil_fee_calculator_openapi_descriptor  = "https://raw.githubusercontent.com/pagopa/mil-apis/main/openapi-mono/fee.yaml"
+mil_fee_calculator_openapi_descriptor  = "https://raw.githubusercontent.com/pagopa/mil-fee-calculator/main/src/main/resources/META-INF/openapi.yaml"
 mil_fee_calculator_quarkus_log_level   = "ERROR"
 mil_fee_calculator_app_log_level       = "DEBUG"
 mil_fee_calculator_gec_connect_timeout = 2000

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -88,7 +88,7 @@ mil_payment_notice_rest_client_read_timeout            = 2000
 mil_payment_notice_closepayment_max_retry              = 10
 mil_payment_notice_closepayment_retry_after            = 1
 mil_payment_notice_activatepayment_expiration_time     = 30000
-mil_payment_notice_image                               = "ghcr.io/pagopa/mil-payment-notice:3.0.0-RC"
+mil_payment_notice_image                               = "ghcr.io/pagopa/mil-payment-notice:latest"
 mil_payment_notice_openapi_descriptor                  = "https://raw.githubusercontent.com/pagopa/mil-payment-notice/main/src/main/resources/META-INF/openapi.yaml"
 mil_payment_notice_cpu                                 = 1
 mil_payment_notice_memory                              = "2Gi"
@@ -99,7 +99,7 @@ mil_payment_notice_min_replicas                        = 1
 # mil-fee-calculator
 #
 mil_fee_calculator_image               = "ghcr.io/pagopa/mil-fee-calculator:latest"
-mil_fee_calculator_openapi_descriptor  = "https://raw.githubusercontent.com/pagopa/mil-apis/main/openapi-mono/fee.yaml"
+mil_fee_calculator_openapi_descriptor  = "https://raw.githubusercontent.com/pagopa/mil-fee-calculator/main/src/main/resources/META-INF/openapi.yaml"
 mil_fee_calculator_quarkus_log_level   = "ERROR"
 mil_fee_calculator_app_log_level       = "DEBUG"
 mil_fee_calculator_gec_connect_timeout = 2000


### PR DESCRIPTION
Added environment variables to Container Apps to export OTel traces to Application Insights.

Container Apps revision mode changed to Single.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
